### PR TITLE
Tested code against CDH 5.2.1 and made modification to correct the build...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ target/
 .AppleDouble
 .LSOverride
 Icon
+*.jar
 
 #Thumbnails
 ._*
@@ -14,3 +15,6 @@ Icon
 .classpath
 .project
 .settings/
+
+# Vim
+*.swp

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ###Cloudera Impala JDBC Example
 
-This branch is for Cloudera Impala included with CDH 5.1.0
+This branch is for Cloudera Impala included with CDH 5.2.1
 
 This example shows how to build and run a maven-based project that executes SQL queries on Cloudera Impala using JDBC. 
 Cloudera Impala is a native Massive Parallel Processing (MPP) query engine which enables users to perform interactive analysis of data stored in HBase or HDFS. 
@@ -67,11 +67,14 @@ To build the project, run the command:
 
 from the root of the project directory. 
 
+Note that this will build the project for the version of CDH (Hive andd Hadoop) specified in the POM file. If the version of your CDH differs from the one in that file, run the following script to build the project for your current CDH version:
+
+	./build-for-current-cdh.sh
 
 ####Running the example using maven
 To run the example using maven, use the command:
 
-	mvn exec:java -Dexec.mainClass=com.cloudera.example.ClouderaImpalaJdbcExample
+	mvn exec:java -Dexec.mainClass=com.cloudera.example.ClouderaImpalaJdbcExample -Dexec.arguments="SELECT description FROM sample_07 limit 10"
 
 from the root of the project directory.  There is a `run-with-maven.sh` script included in this project.
 
@@ -122,33 +125,25 @@ Here is sample output from running the example:
 	
 
 ####Running the example outside of maven
-To run this example outside of maven, add all of the jars that correspond to the dependencies referenced in this project's pom to the classpath.  There is an example `run.sh` script included in this project that provides an example of how to set the classpath.  Edit the script so the paths are correct on your system.
+To run this example outside of maven, add all of the jars that correspond to the dependencies referenced in this project's pom to the classpath.  There is an example `run.sh` script included in this project that provides an example of how to set the classpath.  The script uses "hadoop classpath" to configure the classpath correctly. If the "hadoop" command line utility is not available you may have to edit the script so the paths are correct on your system.
 
-Here are the relevant paths for jars to add to the classpath, using the default locations for Cloudera Impala included in CDH 5.1.0 installed via [parcels](http://blog.cloudera.com/blog/2013/05/faq-understanding-the-parcel-binary-distribution-format/):
+Here are the relevant paths for jars to add to the classpath, using the default locations for Cloudera Impala included in CDH 5.2.1 installed via [parcels](http://blog.cloudera.com/blog/2013/05/faq-understanding-the-parcel-binary-distribution-format/):
 
-	HADOOP_CLIENT_DIR=/opt/cloudera/parcels/CDH/lib/hadoop/client/
-	HIVE_LIB_DIR=/opt/cloudera/parcels/CDH/lib/hive/lib
-	IMPALA_LIB_DIR=/opt/cloudera/parcels/CDH/lib/impala/lib
-	
-	CLASSPATH=$HIVE_LIB_DIR/hive-jdbc.jar
-	CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/hive-metastore.jar
-	CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/hive-common.jar
-	CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/hive-service.jar
-	CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/libfb303-0.9.0.jar
-	CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/libthrift-0.9.0.cloudera.2.jar
-	CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/commons-logging-1.1.3.jar
-	CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/log4j-1.2.16.jar
-	CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/slf4j-api-1.7.5.jar
-	
-	CLASSPATH=$CLASSPATH:$IMPALA_LIB_DIR/slf4j-log4j12-1.7.5.jar
-	
-	CLASSPATH=$CLASSPATH:$HADOOP_CLIENT_DIR/hadoop-common.jar
-	CLASSPATH=$CLASSPATH:$HADOOP_CLIENT_DIR/httpcore.jar
-	CLASSPATH=$CLASSPATH:$HADOOP_CLIENT_DIR/httpclient.jar
-	
-	CLASSPATH=$CLASSPATH:./cloudera-impala-jdbc-example-1.0.jar
-	
-	java -cp $CLASSPATH com.cloudera.example.ClouderaImpalaJdbcExample
+        CDH_HOME=/opt/cloudera/parcels/CDH
+        HIVE_LIB_DIR=$CDH_HOME/lib/hive/lib
+        IMPALA_LIB_DIR=$CDH_HOME/lib/impala/lib
+        HADOOP_CLIENT_DIR=$CDH_HOME/lib/hadoop/client
+
+        CLASSPATH=$HADOOP_CLIENT_DIR/hadoop-common.jar
+        CLASSPATH=$CLASSPATH:$HADOOP_CLIENT_DIR/httpclient.jar
+        CLASSPATH=$CLASSPATH:$HADOOP_CLIENT_DIR/httpcore.jar
+        CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/commons-logging-1.1.3.jar
+        CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/hive-exec.jar
+        CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/hive-jdbc.jar
+        CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/hive-service.jar
+        CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/log4j-1.2.16.jar
+        CLASSPATH=$CLASSPATH:$IMPALA_LIB_DIR/slf4j-api-1.7.5.jar
+        CLASSPATH=$CLASSPATH:$IMPALA_LIB_DIR/slf4j-log4j12-1.7.5.jar
 
 And here is the output from running the example outside of maven:
 

--- a/build-for-current-cdh.sh
+++ b/build-for-current-cdh.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Abort in case of errors
+set -e
+
+# Globals
+readonly BASE_DIR=$( readlink -f $( dirname $0 )/.. )
+readonly CDH_HOME=/opt/cloudera/parcels/CDH
+readonly HIVE_LIB_DIR=$CDH_HOME/lib/hive/lib
+readonly HADOOP_LIB_DIR=$CDH_HOME/lib/hadoop
+
+readonly CDH_VERSION=$( readlink -f $CDH_HOME | sed 's/^[^-]*-\([^-]*\)-.*/\1/' )
+
+function get_version {
+  local dir=$1
+  local prefix=$2
+
+  echo $( find $dir -name "$prefix*.jar" | tail -1 | sed "s/^.*\/$prefix//" | sed 's/\.jar//' )
+}
+
+function build {
+  local cdh_hive_version=$( get_version $HIVE_LIB_DIR hive-common- )
+  local cdh_hadoop_version=$( get_version $HADOOP_LIB_DIR hadoop-common- )
+  echo "Building for:"
+  echo "  CDH    = $CDH_VERSION"
+  echo "  Hive   = $cdh_hive_version"
+  echo "  Hadoop = $cdh_hadoop_version"
+  mvn clean package \
+    -Dcdh5.hive.version=$cdh5_hive_version \
+    -Dcdh5.hadoop.version=$cdh5_hadoop_version \
+    -DskipTests
+}
+
+function main() {
+  # Build 
+  build
+
+  echo "Done!"
+}
+
+### MAIN ###
+main

--- a/pom.xml
+++ b/pom.xml
@@ -12,88 +12,22 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+                <cdh.hive.version>0.13.1-cdh5.2.1</cdh.hive.version>
+                <cdh.hadoop.version>2.5.0-cdh5.2.1</cdh.hadoop.version>
 	</properties>
 	
 	<dependencies>
-	
 		<dependency>
 			<groupId>org.apache.hive</groupId>
 			<artifactId>hive-jdbc</artifactId>
-			<version>0.12.0-cdh5.1.0</version>
+			<version>${cdh.hive.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.apache.hive</groupId>
-			<artifactId>hive-metastore</artifactId>
-			<version>0.12.0-cdh5.1.0</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.hive</groupId>
-			<artifactId>hive-service</artifactId>
-			<version>0.12.0-cdh5.1.0</version>
-		</dependency>
-		
-		<dependency>
-			<groupId>org.apache.hive</groupId>
-			<artifactId>hive-common</artifactId>
-			<version>0.12.0-cdh5.1.0</version>
-		</dependency>
-		
 		<dependency>
   			<groupId>org.apache.hadoop</groupId>
   			<artifactId>hadoop-common</artifactId>
-  			<version>2.3.0-cdh5.1.0</version>
+  			<version>${cdh.hadoop.version}</version>
 		</dependency>
-
-		<dependency>
-			<groupId>org.apache.thrift</groupId>
-			<artifactId>libfb303</artifactId>
-			<version>0.9.0</version>
-		</dependency>
-		
-		<dependency>
-			<groupId>org.apache.thrift</groupId>
-			<artifactId>libthrift</artifactId>
-			<version>0.9.0.cloudera.2</version>
-		</dependency>
-		
-		<dependency>
-			<groupId>commons-logging</groupId>
-			<artifactId>commons-logging</artifactId>
-			<version>1.1.3</version>
-		</dependency>
-
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.16</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.7.5</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.7.5</version>
-		</dependency>
-		
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpcore</artifactId>
-			<version>4.2.5</version>
-		</dependency>
-		
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
-			<version>4.2.5</version>
-		</dependency>
-		
 	</dependencies>
 
 	<build>
@@ -126,7 +60,21 @@
 					<outputDirectory>${basedir}</outputDirectory>
 				</configuration>
 			</plugin>
-
+			<plugin>
+                                <artifactId>maven-clean-plugin</artifactId>
+                                <version>2.6.1</version>
+                                <configuration>
+                                        <filesets>
+                                                <fileset>
+                                                        <directory>.</directory>
+                                                        <includes>
+                                                                <include>*.jar</include>
+                                                        </includes>
+                                                        <followSymlinks>false</followSymlinks>
+                                                </fileset>
+                                        </filesets>
+                                </configuration>
+                        </plugin>
 		</plugins>
 	</build>
 

--- a/run-with-maven.sh
+++ b/run-with-maven.sh
@@ -1,1 +1,8 @@
-mvn exec:java -Dexec.mainClass=com.cloudera.example.ClouderaImpalaJdbcExample
+BASE_DIR=$( dirname $( readlink -f $0 ) )
+JAR_FILE=$( ls -1 $BASE_DIR/cloudera-impala-jdbc-example-*.jar 2> /dev/null )
+
+if [ ! -f "$JAR_FILE" ]; then
+  $BASE_DIR/build-for-current-cdh.sh
+fi
+
+mvn exec:java -Dexec.mainClass=com.cloudera.example.ClouderaImpalaJdbcExample -Dexec.arguments="SELECT description FROM sample_07 limit 10"

--- a/run.sh
+++ b/run.sh
@@ -1,23 +1,29 @@
-HADOOP_CLIENT_DIR=/opt/cloudera/parcels/CDH/lib/hadoop/client/
-HIVE_LIB_DIR=/opt/cloudera/parcels/CDH/lib/hive/lib
-IMPALA_LIB_DIR=/opt/cloudera/parcels/CDH/lib/impala/lib
+BASE_DIR=$( dirname $( readlink -f $0 ) )
+CDH_HOME=/opt/cloudera/parcels/CDH
+HIVE_LIB_DIR=$CDH_HOME/lib/hive/lib
+IMPALA_LIB_DIR=$CDH_HOME/lib/impala/lib
+HADOOP_CLIENT_DIR=$CDH_HOME/lib/hadoop/client
 
-CLASSPATH=$HIVE_LIB_DIR/hive-jdbc.jar
-CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/hive-metastore.jar
-CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/hive-common.jar
+JAR_FILE=$( ls -1 $BASE_DIR/cloudera-impala-jdbc-example-*.jar )
+
+type hadoop > /dev/null 2>&1
+if [ $? == 0 ]; then
+  CLASSPATH=$( hadoop classpath )
+else
+  CLASSPATH=$HADOOP_CLIENT_DIR/hadoop-common.jar
+  CLASSPATH=$CLASSPATH:$HADOOP_CLIENT_DIR/httpclient.jar
+  CLASSPATH=$CLASSPATH:$HADOOP_CLIENT_DIR/httpcore.jar
+  # the versions below work for CDH 5.2.1
+  CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/commons-logging-1.1.3.jar
+  CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/log4j-1.2.16.jar
+  CLASSPATH=$CLASSPATH:$IMPALA_LIB_DIR/slf4j-api-1.7.5.jar
+  CLASSPATH=$CLASSPATH:$IMPALA_LIB_DIR/slf4j-log4j12-1.7.5.jar
+fi
+
+CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/hive-jdbc.jar
+CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/hive-exec.jar
 CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/hive-service.jar
-CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/libfb303-0.9.0.jar
-CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/libthrift-0.9.0.cloudera.2.jar
-CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/commons-logging-1.1.3.jar
-CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/log4j-1.2.16.jar
-CLASSPATH=$CLASSPATH:$HIVE_LIB_DIR/slf4j-api-1.7.5.jar
 
-CLASSPATH=$CLASSPATH:$IMPALA_LIB_DIR/slf4j-log4j12-1.7.5.jar
+CLASSPATH=$CLASSPATH:$JAR_FILE
 
-CLASSPATH=$CLASSPATH:$HADOOP_CLIENT_DIR/hadoop-common.jar
-CLASSPATH=$CLASSPATH:$HADOOP_CLIENT_DIR/httpcore.jar
-CLASSPATH=$CLASSPATH:$HADOOP_CLIENT_DIR/httpclient.jar
-
-CLASSPATH=$CLASSPATH:./cloudera-impala-jdbc-example-1.0.jar
-
-java -cp $CLASSPATH com.cloudera.example.ClouderaImpalaJdbcExample
+java -cp $CLASSPATH com.cloudera.example.ClouderaImpalaJdbcExample "SELECT description FROM sample_07 limit 10"

--- a/src/main/resources/ClouderaImpalaJdbcExample.conf
+++ b/src/main/resources/ClouderaImpalaJdbcExample.conf
@@ -1,0 +1,2 @@
+connection.url = jdbc:hive2://IMPALAD_HOST:IMPALAD_JDBC_PORT/;auth=noSasl
+jdbc.driver.class.name = org.apache.hive.jdbc.HiveDriver


### PR DESCRIPTION
Hey, Mark,

I had to run your example against CDH 5.2.1 and made a few changes to make it work.
Please see below.

Regards,
Andre

....

Moved hard-coded configuration from the main class to a configuration file.
Modified main class to read cconfiguration from that file.
Removed hard-coded query from the code and changed code to accept it as a parameter,
  which should make it simpler run different queries for testing.
Cleaned up the POM file, removing unnecessary dependencies.
Parameterized the POM file to allow specifying dependency versions from the command line.
Created a build-for-current-cdh.sh script that checks versions for the installed CDH and
  run the build for those versions. This should help the project to build correctly for
  many CDH versions without any required modifications.
Updated run.sh and run-with-maven.sh scripts to reflect the changes made above.
Updated README with latest modifications.
Tested everything.
